### PR TITLE
Dispatch event when adding new record

### DIFF
--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -48,6 +48,7 @@ describe('#nestedForm', (): void => {
     const controllerElement: HTMLButtonElement = document.querySelector("[data-controller='nested-form']")
     const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
 
+    // @ts-ignore following line
     jest.spyOn(global, 'Event').mockImplementation((type: string, eventInit?: any) => ({ type, eventInit }))
     const mockDispatchEvent = jest.spyOn(controllerElement, 'dispatchEvent').mockImplementation(() => true)
 

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -43,4 +43,18 @@ describe('#nestedForm', (): void => {
 
     expect(target.previousElementSibling.innerHTML).toContain('New todo')
   })
+
+  it('should dispatch events', (): void => {
+    const controllerElement: HTMLButtonElement = document.querySelector("[data-controller='nested-form']")
+    const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+
+    jest.spyOn(global, 'Event').mockImplementation((type: string, eventInit?: any) => ({ type, eventInit }))
+    const mockDispatchEvent = jest.spyOn(controllerElement, 'dispatchEvent').mockImplementation(() => true)
+
+    addButton.click()
+
+    expect(mockDispatchEvent).toHaveBeenCalledWith({
+      type: 'nested-form:add'
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export default class extends Controller {
 
     const content: string = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime().toString())
     this.targetTarget.insertAdjacentHTML('beforebegin', content)
+
+    this.element.dispatchEvent(new Event('nested-form:add', { bubbles: true }))
   }
 
   remove (e: Event): void {


### PR DESCRIPTION
This will fire an event named `nested-form:add` on the controller element, which can be used to trigger other updates on the page as needed.

* Spec added to cover this, with special mocking to listen for the event.
* Linted and formatted

If this is successful I'd be happy to add `nested-form:remove` as well. 