### PR TITLE
prevent name collision

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,8 @@ export default class extends Controller {
     // Retrieve the wrapper selector from values
     const wrapperSelector = this.wrapperSelectorValue || '.nested-form-wrapper';
 
-    const targetElement = e.target as Element;
     // Find the closest wrapper to the event's target
-    const wrapper = targetElement.closest(wrapperSelector);
+    const wrapper = (event.target as Element).closest(wrapperSelector);
     if (wrapper?.dataset.newRecord === 'true') {
       wrapper.remove();
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,26 +13,56 @@ export default class extends Controller {
     }
   }
 
-  add (e: Event) {
+  add(e: Event) {
     e.preventDefault()
 
-    const content: string = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime().toString())
+    // Generate a unique identifier based on the current time
+    const uniqueId = new Date().getTime().toString()
+
+    // Clone the template content and replace NEW_RECORD with uniqueId
+    let content = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, uniqueId)
+
+    // Insert the cloned and modified content before the target
     this.targetTarget.insertAdjacentHTML('beforebegin', content)
+
+    // Find the last set of fields added and adjust their attributes
+    const lastAddedFields = this.element.querySelector(`[data-fields-id="${uniqueId}"]`);
+    if (lastAddedFields) {
+      lastAddedFields.querySelectorAll('input, select, textarea').forEach((input) => {
+        if (input.hasAttribute('name')) {
+          const updatedName = input.getAttribute('name').replace(/\[\d+\]/, `[${uniqueId}]`);
+          input.setAttribute('name', updatedName);
+        }
+        if (input.hasAttribute('id')) {
+          const updatedId = input.getAttribute('id').replace(/_\d+/, `_${uniqueId}`);
+          input.setAttribute('id', updatedId);
+        }
+      });
+
+      // Update the 'for' attributes of associated labels
+      lastAddedFields.querySelectorAll('label').forEach((label) => {
+        if (label.hasAttribute('for')) {
+          const updatedFor = label.getAttribute('for').replace(/_\d+/, `_${uniqueId}`);
+          label.setAttribute('for', updatedFor);
+        }
+      });
+    }
   }
 
-  remove (e: Event): void {
+  remove(e: Event): void {
     e.preventDefault()
 
-    // @ts-ignore
-    const wrapper: HTMLElement = e.target.closest(this.wrapperSelectorValue)
+    //@ts-ignore
+    // Find the closest wrapper using the provided selector value
+    const wrapper = e.target.closest(this.wrapperSelectorValue)
 
     if (wrapper.dataset.newRecord === 'true') {
-      wrapper.remove()
+      wrapper.remove() // Remove the wrapper if it's a newly added record
     } else {
-      wrapper.style.display = 'none'
-
-      const input: HTMLInputElement = wrapper.querySelector("input[name*='_destroy']")
-      input.value = '1'
+      wrapper.style.display = 'none' // Hide the wrapper for existing records
+      //@ts-ignore
+      const input = wrapper.querySelector("input[name*='_destroy']")
+      input.value = '1' // Mark the record for destruction on form submission
     }
   }
 }


### PR DESCRIPTION
When using the stimulus-rails-nested-form library to dynamically add nested form fields, it has been observed that if the "add" action is triggered multiple times, the newly added input fields end up having the same name attribute value. This behavior results in only the last input's data being submitted, as the preceding input values are overwritten due to the shared name attribute among them. This issue fundamentally affects the form's ability to correctly handle multiple nested records, leading to data loss and inconsistent submissions.

I propose modifying the nested form field addition process to include a unique identifier within each name attribute of newly added input fields. This can be achieved by appending a timestamp or a sequentially incremented value to the name attribute, ensuring its uniqueness across the form. I have prepared a pull request that implements this solution by extending the current functionality of the stimulus-rails-nested-form library's controller to include this adjustment.